### PR TITLE
Fix IE 10/11 issue with `XMLHttpRequest.send(undefined)`

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -992,7 +992,19 @@ Request.prototype.end = function(fn){
 
   // send stuff
   this.emit('request', this);
-  xhr.send(data);
+
+  if (typeof data !== 'undefined') {
+    xhr.send(data);
+  } else {
+    // The XMLHttpRequest specification does not explicitly define `send(undefined)`, but `send()`
+    // or `send(null)` are accepted. While most browsers treat `undefined` and `null` as acceptable,
+    // IE 10/11 convert `undefined` into the body "undefined" with text/plain as the content type.
+    //
+    // XMLHttpRequest Level 1: http://www.w3.org/TR/XMLHttpRequest/#the-send()-method
+    // XMLHttpRequest Living Standard: https://xhr.spec.whatwg.org/#the-send()-method
+    xhr.send();
+  }
+
   return this;
 };
 

--- a/test/client/request.js
+++ b/test/client/request.js
@@ -185,6 +185,15 @@ it('post() data', function(next){
   });
 });
 
+it('post() with no data', function(next){
+  request.post('/echo')
+  .send()
+  .end(function(err, res){
+    assert('' == res.text, 'response text');
+    next();
+  });
+});
+
 it('request .type()', function(next){
   request
   .post('/user/12/pet')


### PR DESCRIPTION
Fixes an issue where `Request#end` would call `XMLHttpRequest.send(undefined)`, causing an issue in Internet Explorer 10 and 11. In these browsers, `XMLHttpRequest.send(undefined)` will cause a request body of "undefined" to be sent by the browser (e.g. on a POST). This causes the `XMLHttpRequest` to assume a request body of type `text/plain` (as Content-Type), which confuses some server software.

Before this change, calling `Request#end` without supplying a request body would cause a call to `XMLHttpRequest.send(undefined)`. After the change, `Request#end` calls `XMLHttpRequest.send(data)` if data is defined for the request, or `XMLHttpRequest.send()` if no data is defined.

This change is in compliance with the "Level 1" and "Living Standard" standards documents for [XMLHttpRequest] (https://xhr.spec.whatwg.org/#the-send()-method), which permits a call to `send()` without parameters. It also appears that calling `send(undefined)` is not explicitly permitted by the standard, although most browsers seem to treat `null` and `undefined` equally.

I've added a test to verify the behavior. Before the fix, I verified that the test did not run on these browsers prior to the fix (using the Sauce Labs setup locally).